### PR TITLE
Standardize CI (tier: unimportant)

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,49 +1,17 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+name: pkgdown
 on:
   push:
     branches: [main, master]
   pull_request:
+    branches: [main, master]
   release:
     types: [published]
   workflow_dispatch:
-
-name: pkgdown.yaml
-
-permissions: read-all
-
+permissions:
+  contents: write
 jobs:
   pkgdown:
-    runs-on: ubuntu-latest
-    # Only restrict concurrency for non-PR jobs
-    concurrency:
-      group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
-    env:
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: r-lib/actions/setup-pandoc@v2
-
-      - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::pkgdown, local::.
-          needs: website
-
-      - name: Build site
-        run: pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
-        shell: Rscript {0}
-
-      - name: Deploy to GitHub pages 🚀
-        if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
-        with:
-          clean: false
-          branch: gh-pages
-          folder: docs
+    uses: poissonconsulting/.github/.github/workflows/pkgdown.yaml@v1
+    with:
+      private: false
+    secrets: inherit

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -1,4 +1,4 @@
-name: R-CMD-check
+name: test-coverage
 on:
   push:
     branches: [main, master]
@@ -7,11 +7,9 @@ on:
 permissions:
   contents: read
 jobs:
-  R-CMD-check:
-    uses: poissonconsulting/.github/.github/workflows/R-CMD-check.yaml@v1
+  test-coverage:
+    uses: poissonconsulting/.github/.github/workflows/test-coverage.yaml@v1
     with:
-      tier: unimportant
-      jags: false
       tex: false
       private: false
     secrets: inherit


### PR DESCRIPTION
Standardizes CI onto the reusable workflows in `poissonconsulting/.github` (tier **unimportant**, private=false, jags=false, tex=false). Callers: R-CMD-check, test-coverage, pkgdown; fledge callers unchanged.